### PR TITLE
Add NULL check in streamdump.c

### DIFF
--- a/src/streamdump.c
+++ b/src/streamdump.c
@@ -70,7 +70,7 @@ void *buf, size_t bufsize )
 
 static void net123_close_internal(struct net123_handle_struct *nh)
 {
-	if(nh)
+	if(!nh)
 		return;
 	int *fdp = nh->parts;
 #ifdef WANT_WIN32_SOCKETS


### PR DESCRIPTION
There is a missing NULL check. Other functions exit when !nh. In this case, without the '!', if it is not NULL, it returns. If it is NULL it continues to line 75 where it does a NULL dereference and crashes.